### PR TITLE
Daemon manager update

### DIFF
--- a/src/components/DaemonManager.tsx
+++ b/src/components/DaemonManager.tsx
@@ -96,21 +96,14 @@ const DaemonManager = () => {
     selectCurrentIdea]);
 
   useEffect(() => {
-    const interval = setInterval(() => {
-      if (!openAIKey) {
-        dispatchError('OpenAI API key not set');
-        return;
-      }
-  
-      if (ideasEligbleForComments.length > 0) {
-        handleDaemonDispatch();
-      }
-    }, 1000);
-
-    return () => clearInterval(interval);
+    if (!openAIKey) {
+      dispatchError('OpenAI API key not set');
+    } else if (ideasEligbleForComments.length > 0) {
+      handleDaemonDispatch();
+    }
   }, [handleDaemonDispatch,
-      ideasEligbleForComments,
-      openAIKey]);
+    ideasEligbleForComments,
+    openAIKey]);
 
   return null;
 }

--- a/src/components/DaemonManager.tsx
+++ b/src/components/DaemonManager.tsx
@@ -10,8 +10,6 @@ import { selectActiveThoughtsEligibleForComments, selectActiveThoughts } from '.
 
 const DaemonManager = () => {
   const dispatch = useAppDispatch();
-  const lastTimeActive = useAppSelector(state => state.ui.lastTimeActive);
-  const [alreadyWasInactive, setAlreadyWasInactive] = useState(false);
   const [chatDaemonActive, setChatDaemonActive] = useState(false);
   const chatDaemonConfigs = useAppSelector(selectEnabledChatDaemons);
   const [chatDaemons, setChatDaemons] = useState<ChatDaemon[]>([]);
@@ -21,7 +19,6 @@ const DaemonManager = () => {
   const openAIKey = useAppSelector(state => state.config.openAIKey);
   const openAIOrgId = useAppSelector(state => state.config.openAIOrgId);
   const chatModel = useAppSelector(state => state.config.chatModel);
-  const maxTimeInactive = 3; // seconds
 
   useEffect(() => {
     const daemons = chatDaemonConfigs.map(config => new ChatDaemon(config));
@@ -63,64 +60,57 @@ const DaemonManager = () => {
 
 
   const handleDaemonDispatch = useCallback(async () => {
-    if (!openAIKey) {
-      dispatchError('OpenAI API key not set');
-      return;
-    }
+    if (!chatDaemonActive) {
+      const currentIdea = await selectCurrentIdea(ideasEligbleForComments);
+      let lastCommentColumn = mostRecentComment ? mostRecentComment.daemonType : '';
+      const pastIdeas = activeThoughts.slice(0, activeThoughts.indexOf(currentIdea));
 
-    if (ideasEligbleForComments.length > 0) {
-      if (chatDaemonActive) {
-        console.log('Chat daemon already active');
-      }
-      else {
-        const currentIdea = await selectCurrentIdea(ideasEligbleForComments);
-        let lastCommentColumn = mostRecentComment ? mostRecentComment.daemonType : '';
-        const pastIdeas = activeThoughts.slice(0, activeThoughts.indexOf(currentIdea));
+      // To maintain backwards compatibility with base/chat naming
+      if (lastCommentColumn === 'base') { lastCommentColumn = 'left'; }
+      if (lastCommentColumn === 'chat') { lastCommentColumn = 'right'; }
 
-        // To maintain backwards compatibility with base/chat naming
-        if (lastCommentColumn === 'base') { lastCommentColumn = 'left'; }
-        if (lastCommentColumn === 'chat') { lastCommentColumn = 'right'; }
+      const column = lastCommentColumn === 'left' ? 'right' : 'left';
 
-        const column = lastCommentColumn === 'left' ? 'right' : 'left';
-
-        if (currentIdea.mention) {
-          const mentionedDaemon = chatDaemons.find(daemon => daemon.config.name === currentIdea.mention);
-          if (mentionedDaemon) {
-            dispatchChatComment(pastIdeas, currentIdea, mentionedDaemon, column);
-          }
+      if (currentIdea.mention) {
+        const mentionedDaemon = chatDaemons.find(daemon => daemon.config.name === currentIdea.mention);
+        if (mentionedDaemon) {
+          dispatchChatComment(pastIdeas, currentIdea, mentionedDaemon, column);
         }
         else {
-          // Randomly select daemon
-          const daemon = chatDaemons[Math.floor(Math.random() * chatDaemons.length)];
-          dispatchChatComment(pastIdeas, currentIdea, daemon, column);
+          dispatchError(`Daemon ${currentIdea.mention} not found`);
+          setChatDaemonActive(false);
         }
+      }
+      else {
+        // Randomly select daemon
+        const daemon = chatDaemons[Math.floor(Math.random() * chatDaemons.length)];
+        dispatchChatComment(pastIdeas, currentIdea, daemon, column);
       }
     }
   }, [ideasEligbleForComments,
     activeThoughts,
     chatDaemonActive,
     chatDaemons,
-    openAIKey,
     mostRecentComment,
     dispatchChatComment,
     selectCurrentIdea]);
 
   useEffect(() => {
     const interval = setInterval(() => {
-      const secondsSinceLastActive = (new Date().getTime() - new Date(lastTimeActive).getTime()) / 1000;
-      if (secondsSinceLastActive > maxTimeInactive && !alreadyWasInactive) {
-        setAlreadyWasInactive(true);
-        handleDaemonDispatch();
+      if (!openAIKey) {
+        dispatchError('OpenAI API key not set');
+        return;
       }
-      if (secondsSinceLastActive < maxTimeInactive && alreadyWasInactive) {
-        setAlreadyWasInactive(false);
+  
+      if (ideasEligbleForComments.length > 0) {
+        handleDaemonDispatch();
       }
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [lastTimeActive,
-    alreadyWasInactive,
-    handleDaemonDispatch]);
+  }, [handleDaemonDispatch,
+      ideasEligbleForComments,
+      openAIKey]);
 
   return null;
 }

--- a/src/redux/ideaSlice.ts
+++ b/src/redux/ideaSlice.ts
@@ -92,7 +92,11 @@ export const selectActiveThoughtsEligibleForComments = createSelector(
       // filter out ideas that are not thoughts
       const activeBranchIdeas = activeIdeaIds.map(id => ideas[id]).filter(idea => (idea.type === IdeaType.User));
       const activeBranchComments = Object.values(comments).filter(comment => activeIdeaIds.includes(comment.ideaId));
-      return getIdeasSinceLastComment(activeBranchIdeas, activeBranchComments);
+      
+      // filter out the root idea
+      const nonRootIdeas = activeBranchIdeas.filter(idea => idea.parentIdeaId !== null && activeIdeaIds.includes(idea.parentIdeaId));
+      
+      return getIdeasSinceLastComment(nonRootIdeas, activeBranchComments);
     } catch (e) {
       if (e instanceof TypeError) {
         // The active tree was probably deleted


### PR DESCRIPTION
I removed the mechanism where the system waits for user inactivity. I think this is pretty unnecessary, and as long as there are eligible comments I see no reason the system shouldn't be working on generating comments for them. This should speed up comment generation by 3 seconds, which I think the user will appreciate. I also made it so the very first idea in a branch is not eligible for a comment, to avoid weirdness where {PAST} is empty. 

I did not look into doing anything to remove the "last time active" variable. Maybe we'll use it for something else in the future?